### PR TITLE
add support for auth token

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -7,6 +7,7 @@ const pkgDir = require('pkg-dir')
 const readPackageTree = require('read-package-tree')
 const RegistryClient = require('npm-registry-client') // TODO: use npm-registry-fetch
 const registryUrl = require('registry-url')
+const registryAuthToken = require('registry-auth-token')
 const stripAnsi = require('strip-ansi')
 const textTable = require('text-table')
 
@@ -90,7 +91,8 @@ async function init () {
 
     const opts = {
       timeout: 30 * 1000,
-      staleOk: true
+      staleOk: true,
+      auth: registryAuthToken()
     }
     return client.getAsync(url, opts)
   }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "pify": "^3.0.0",
     "pkg-dir": "^2.0.0",
     "read-package-tree": "^5.1.6",
+    "registry-auth-token": "^3.3.2",
     "registry-url": "^3.1.0",
     "strip-ansi": "^4.0.0",
     "text-table": "^0.2.0"


### PR DESCRIPTION
Adds support for npm auth token otherwise the script fails when there are private packages in `node_modules`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/feross/thanks/3)
<!-- Reviewable:end -->
