### PR TITLE
replace prepublish with prepublishOnly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist/
+node_modules

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "scripts": {
     "build": "mkdir -p dist && babel src/cmd.js > dist/cmd.js && chmod +x dist/cmd.js",
-    "prepublish": "npm run build",
+    "prepublishOnly": "npm run build",
     "test": "standard && npm run build && ./dist/cmd.js --no-open"
   }
 }


### PR DESCRIPTION
prepublishOnly runs only before `npm publish` whether prepublish also
runs after `npm install`

---

I was going to test something and realised that `node_modules` was missing from .gitignore so I added it as well.

Usually, I build only before `npm install` so I thought maybe you wanted that too. Sorry for the inconvenience if that isn't the case 🙂 